### PR TITLE
initial-schema-setup

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@getpara/server-sdk": "^1.18.0",
+    "@nestjs/axios": "^4.0.1",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
@@ -28,6 +29,7 @@
     "@nestjs/swagger": "^11.2.0",
     "@repo/db": "workspace:*",
     "@types/pg": "^8.15.4",
+    "axios": "^1.10.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "drizzle-orm": "^0.44.2",

--- a/apps/server/src/database/index.ts
+++ b/apps/server/src/database/index.ts
@@ -1,0 +1,2 @@
+export * from './schemas';
+export * from './relations';

--- a/apps/server/src/database/relations.ts
+++ b/apps/server/src/database/relations.ts
@@ -1,0 +1,139 @@
+import { relations } from 'drizzle-orm';
+import {
+  users,
+  roles,
+  games,
+  gameMode,
+  gameAccess,
+  participants,
+  athletes,
+  stats,
+  predictions,
+  matchups,
+  matchupPerformance,
+  leaderboard,
+} from './schemas';
+
+// User relations
+export const usersRelations = relations(users, ({ one, many }) => ({
+  role: one(roles, {
+    fields: [users.roleId],
+    references: [roles.id],
+  }),
+  createdGames: many(games),
+  participations: many(participants),
+  gameAccess: many(gameAccess),
+}));
+
+export const rolesRelations = relations(roles, ({ many }) => ({
+  users: many(users),
+}));
+
+// Game relations
+export const gamesRelations = relations(games, ({ one, many }) => ({
+  creator: one(users, {
+    fields: [games.creatorId],
+    references: [users.id],
+  }),
+  gameMode: one(gameMode, {
+    fields: [games.gameModeId],
+    references: [gameMode.id],
+  }),
+  participants: many(participants),
+  leaderboard: many(leaderboard),
+  gameAccess: many(gameAccess),
+}));
+
+export const gameModeRelations = relations(gameMode, ({ many }) => ({
+  games: many(games),
+}));
+
+export const gameAccessRelations = relations(gameAccess, ({ one }) => ({
+  game: one(games, {
+    fields: [gameAccess.gameId],
+    references: [games.id],
+  }),
+  user: one(users, {
+    fields: [gameAccess.userId],
+    references: [users.id],
+  }),
+}));
+
+// Participant relations
+export const participantsRelations = relations(
+  participants,
+  ({ one, many }) => ({
+    user: one(users, {
+      fields: [participants.userId],
+      references: [users.id],
+    }),
+    game: one(games, {
+      fields: [participants.gameId],
+      references: [games.id],
+    }),
+    predictions: many(predictions),
+    leaderboard: many(leaderboard),
+  }),
+);
+
+// Athlete relations
+export const athletesRelations = relations(athletes, ({ many }) => ({
+  predictions: many(predictions),
+  matchupPerformances: many(matchupPerformance),
+}));
+
+// Prediction relations
+export const predictionsRelations = relations(predictions, ({ one }) => ({
+  participant: one(participants, {
+    fields: [predictions.participantId],
+    references: [participants.id],
+  }),
+  athlete: one(athletes, {
+    fields: [predictions.athleteId],
+    references: [athletes.id],
+  }),
+  stat: one(stats, {
+    fields: [predictions.statId],
+    references: [stats.id],
+  }),
+  matchup: one(matchups, {
+    fields: [predictions.matchupId],
+    references: [matchups.id],
+  }),
+}));
+
+export const statsRelations = relations(stats, ({ many }) => ({
+  predictions: many(predictions),
+}));
+
+// Matchup relations
+export const matchupsRelations = relations(matchups, ({ many }) => ({
+  predictions: many(predictions),
+  performances: many(matchupPerformance),
+}));
+
+export const matchupPerformanceRelations = relations(
+  matchupPerformance,
+  ({ one }) => ({
+    matchup: one(matchups, {
+      fields: [matchupPerformance.matchupId],
+      references: [matchups.id],
+    }),
+    athlete: one(athletes, {
+      fields: [matchupPerformance.athleteId],
+      references: [athletes.id],
+    }),
+  }),
+);
+
+// Leaderboard relations
+export const leaderboardRelations = relations(leaderboard, ({ one }) => ({
+  game: one(games, {
+    fields: [leaderboard.gameId],
+    references: [games.id],
+  }),
+  participant: one(participants, {
+    fields: [leaderboard.participantId],
+    references: [participants.id],
+  }),
+}));

--- a/apps/server/src/database/schemas/athlete.schema.ts
+++ b/apps/server/src/database/schemas/athlete.schema.ts
@@ -1,0 +1,14 @@
+import { pgTable, uuid, varchar, integer } from 'drizzle-orm/pg-core';
+
+export const athletes = pgTable('athletes', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: varchar('name', { length: 255 }).notNull(),
+  team: varchar('team', { length: 100 }).notNull(),
+  position: varchar('position', { length: 50 }).notNull(),
+  jerseyNumber: integer('jersey_number'),
+  age: integer('age'),
+  picture: varchar('picture', { length: 500 }),
+});
+
+export type Athlete = typeof athletes.$inferSelect;
+export type NewAthlete = typeof athletes.$inferInsert;

--- a/apps/server/src/database/schemas/game.schema.ts
+++ b/apps/server/src/database/schemas/game.schema.ts
@@ -1,0 +1,70 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  decimal,
+  timestamp,
+  boolean,
+  integer,
+  pgEnum,
+} from 'drizzle-orm/pg-core';
+
+export const gameTypeEnum = pgEnum('game_type', [
+  '1v1',
+  'limited',
+  'unlimited',
+]);
+export const userControlTypeEnum = pgEnum('user_control_type', [
+  'whitelist',
+  'blacklist',
+  'none',
+]);
+export const gameAccessStatusEnum = pgEnum('game_access_status', [
+  'whitelisted',
+  'blacklisted',
+]);
+
+export const gameMode = pgTable('game_mode', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  label: varchar('label', { length: 100 }).notNull(),
+  description: varchar('description', { length: 500 }),
+});
+
+export const games = pgTable('games', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  title: varchar('title', { length: 255 }).notNull(),
+  creatorId: uuid('creator_id').notNull(),
+  depositAmount: decimal('deposit_amount', {
+    precision: 18,
+    scale: 8,
+  }).notNull(),
+  currency: varchar('currency', { length: 10 }).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  inviteLink: varchar('invite_link', { length: 500 }),
+  status: varchar('status', { length: 50 }).notNull(),
+  maxParticipants: integer('max_participants'),
+  gameCode: varchar('game_code', { length: 20 }).notNull().unique(),
+  matchupGroup: varchar('matchup_group', { length: 100 }),
+  depositToken: varchar('deposit_token', { length: 100 }),
+  isPrivate: boolean('is_private').default(false).notNull(),
+  type: gameTypeEnum('type').notNull(),
+  gameModeId: uuid('game_mode_id').notNull(),
+  gameAccessId: uuid('game_access_id'),
+  userControlType: userControlTypeEnum('user_control_type')
+    .default('none')
+    .notNull(),
+});
+
+export const gameAccess = pgTable('game_access', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  gameId: uuid('game_id').notNull(),
+  userId: uuid('user_id').notNull(),
+  status: gameAccessStatusEnum('status').notNull(),
+});
+
+export type Game = typeof games.$inferSelect;
+export type NewGame = typeof games.$inferInsert;
+export type GameMode = typeof gameMode.$inferSelect;
+export type NewGameMode = typeof gameMode.$inferInsert;
+export type GameAccess = typeof gameAccess.$inferSelect;
+export type NewGameAccess = typeof gameAccess.$inferInsert;

--- a/apps/server/src/database/schemas/index.ts
+++ b/apps/server/src/database/schemas/index.ts
@@ -1,0 +1,7 @@
+export * from './user.schema';
+export * from './game.schema';
+export * from './participant.schema';
+export * from './athlete.schema';
+export * from './prediction.schema';
+export * from './matchup.schema';
+export * from './leaderboard.schema';

--- a/apps/server/src/database/schemas/leaderboard.schema.ts
+++ b/apps/server/src/database/schemas/leaderboard.schema.ts
@@ -1,0 +1,13 @@
+import { pgTable, uuid, integer } from 'drizzle-orm/pg-core';
+
+export const leaderboard = pgTable('leaderboard', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  gameId: uuid('game_id').notNull(),
+  participantId: uuid('participant_id').notNull(),
+  entriesInProgress: integer('entries_in_progress').default(0).notNull(),
+  entriesCorrect: integer('entries_correct').default(0).notNull(),
+  entriesIncorrect: integer('entries_incorrect').default(0).notNull(),
+});
+
+export type Leaderboard = typeof leaderboard.$inferSelect;
+export type NewLeaderboard = typeof leaderboard.$inferInsert;

--- a/apps/server/src/database/schemas/matchup.schema.ts
+++ b/apps/server/src/database/schemas/matchup.schema.ts
@@ -1,0 +1,30 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  date,
+  integer,
+  json,
+} from 'drizzle-orm/pg-core';
+
+export const matchups = pgTable('matchups', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  gameDate: date('game_date').notNull(),
+  homeTeam: varchar('home_team', { length: 100 }).notNull(),
+  awayTeam: varchar('away_team', { length: 100 }).notNull(),
+  status: varchar('status', { length: 50 }).notNull(), // e.g., scheduled, in_progress, finished
+  scoreHome: integer('score_home'),
+  scoreAway: integer('score_away'),
+});
+
+export const matchupPerformance = pgTable('matchup_performance', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  matchupId: uuid('matchup_id').notNull(),
+  athleteId: uuid('athlete_id').notNull(),
+  stats: json('stats').$type<Record<string, any>>().notNull(),
+});
+
+export type Matchup = typeof matchups.$inferSelect;
+export type NewMatchup = typeof matchups.$inferInsert;
+export type MatchupPerformance = typeof matchupPerformance.$inferSelect;
+export type NewMatchupPerformance = typeof matchupPerformance.$inferInsert;

--- a/apps/server/src/database/schemas/participant.schema.ts
+++ b/apps/server/src/database/schemas/participant.schema.ts
@@ -1,0 +1,12 @@
+import { pgTable, uuid, timestamp, boolean } from 'drizzle-orm/pg-core';
+
+export const participants = pgTable('participants', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id').notNull(),
+  gameId: uuid('game_id').notNull(),
+  joinedAt: timestamp('joined_at').defaultNow().notNull(),
+  isWinner: boolean('is_winner').default(false).notNull(),
+});
+
+export type Participant = typeof participants.$inferSelect;
+export type NewParticipant = typeof participants.$inferInsert;

--- a/apps/server/src/database/schemas/prediction.schema.ts
+++ b/apps/server/src/database/schemas/prediction.schema.ts
@@ -1,0 +1,27 @@
+import { pgTable, uuid, varchar, decimal, boolean } from 'drizzle-orm/pg-core';
+
+export const stats = pgTable('stats', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: varchar('name', { length: 100 }).notNull(),
+  description: varchar('description', { length: 500 }),
+});
+
+export const predictions = pgTable('predictions', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  participantId: uuid('participant_id').notNull(),
+  athleteId: uuid('athlete_id').notNull(),
+  statId: uuid('stat_id').notNull(),
+  matchupId: uuid('matchup_id').notNull(),
+  predictedDirection: varchar('predicted_direction', { length: 10 }).notNull(), // "Higher" or "Lower"
+  predictedValue: decimal('predicted_value', {
+    precision: 10,
+    scale: 2,
+  }).notNull(),
+  actualValue: decimal('actual_value', { precision: 10, scale: 2 }),
+  isCorrect: boolean('is_correct'),
+});
+
+export type Stat = typeof stats.$inferSelect;
+export type NewStat = typeof stats.$inferInsert;
+export type Prediction = typeof predictions.$inferSelect;
+export type NewPrediction = typeof predictions.$inferInsert;

--- a/apps/server/src/database/schemas/user.schema.ts
+++ b/apps/server/src/database/schemas/user.schema.ts
@@ -1,0 +1,19 @@
+import { pgTable, uuid, varchar, timestamp } from 'drizzle-orm/pg-core';
+
+export const users = pgTable('users', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  username: varchar('username', { length: 255 }).notNull(),
+  walletAddress: varchar('wallet_address', { length: 255 }),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  roleId: uuid('role_id').notNull(),
+});
+
+export const roles = pgTable('roles', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: varchar('name', { length: 100 }).notNull(),
+});
+
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;
+export type Role = typeof roles.$inferSelect;
+export type NewRole = typeof roles.$inferInsert;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@getpara/server-sdk':
         specifier: ^1.18.0
         version: 1.18.0
+      '@nestjs/axios':
+        specifier: ^4.0.1
+        version: 4.0.1(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.10.0)(rxjs@7.8.2)
       '@nestjs/common':
         specifier: ^11.0.1
         version: 11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -48,6 +51,9 @@ importers:
       '@types/pg':
         specifier: ^8.15.4
         version: 8.15.4
+      axios:
+        specifier: ^1.10.0
+        version: 1.10.0
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -1428,6 +1434,13 @@ packages:
   '@napi-rs/nice@1.0.1':
     resolution: {integrity: sha512-zM0mVWSXE0a0h9aKACLwKmD6nHcRiKrPpCfvaKqG1CqDEyjEawId0ocXxVzPMCAm6kkWr2P025msfxXEnt8UGQ==}
     engines: {node: '>= 10'}
+
+  '@nestjs/axios@4.0.1':
+    resolution: {integrity: sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      axios: ^1.3.1
+      rxjs: ^7.0.0
 
   '@nestjs/cli@11.0.7':
     resolution: {integrity: sha512-svrP8j1R0/lQVJ8ZI3BlDtuZxmkvVJokUJSB04sr6uibunk2wHeVDDVLZvYBUorCdGU/RHJl1IufhqUBM91vAQ==}
@@ -6886,6 +6899,12 @@ snapshots:
       '@napi-rs/nice-win32-ia32-msvc': 1.0.1
       '@napi-rs/nice-win32-x64-msvc': 1.0.1
     optional: true
+
+  '@nestjs/axios@4.0.1(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.10.0)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      axios: 1.10.0
+      rxjs: 7.8.2
 
   '@nestjs/cli@11.0.7(@swc/cli@0.6.0(@swc/core@1.12.5(@swc/helpers@0.5.15))(chokidar@4.0.3))(@swc/core@1.12.5(@swc/helpers@0.5.15))(@types/node@22.15.3)(esbuild@0.25.5)':
     dependencies:


### PR DESCRIPTION
🗃️ Schema Source

> Data Model Reference: https://app.eraser.io/workspace/DQ497mVZU0PIw1hXLzHB

✨ Changes

1.  Added 8 core schema files with proper table definitions and relationships
2. Implemented type-safe `enums` for `game types` and `user control mechanisms`
3. Created comprehensive relations between all entities (`users`, `games`, `predictions`, etc.)
4. Added TypeScript inference types for all schemas (select/insert)
5. Organized schemas in logical folder structure under `src/database/schemas/`