### PR TITLE
Resolve game tests

### DIFF
--- a/programs/ralli-bet/package-lock.json
+++ b/programs/ralli-bet/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "license": "ISC",
       "dependencies": {
-        "@coral-xyz/anchor": "^0.31.1"
+        "@coral-xyz/anchor": "^0.31.1",
+        "@solana/spl-token": "^0.4.13"
       },
       "devDependencies": {
         "@types/bn.js": "^5.2.0",
@@ -114,6 +115,344 @@
       },
       "engines": {
         "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/buffer-layout-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/web3.js": "^1.32.0",
+        "bigint-buffer": "^1.1.5",
+        "bignumber.js": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@solana/spl-token": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.13.tgz",
+      "integrity": "sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-group": "^0.0.7",
+        "@solana/spl-token-metadata": "^0.1.6",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.5"
+      }
+    },
+    "node_modules/@solana/spl-token-group": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz",
+      "integrity": "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
+      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@solana/web3.js": {
@@ -439,6 +778,28 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bindings": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -450,6 +811,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bn.js": {
@@ -855,6 +1225,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+      "license": "MIT"
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
     "node_modules/fill-range": {

--- a/programs/ralli-bet/package.json
+++ b/programs/ralli-bet/package.json
@@ -6,7 +6,8 @@
     "test": "mocha -t 1000000 -r ts-node/register tests/**/*.ts"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "^0.31.1"
+    "@coral-xyz/anchor": "^0.31.1",
+    "@solana/spl-token": "^0.4.13"
   },
   "devDependencies": {
     "@types/bn.js": "^5.2.0",

--- a/programs/ralli-bet/programs/ralli-bet/src/errors.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/errors.rs
@@ -220,4 +220,10 @@ pub enum RalliError {
 
     #[msg("User account is not available")]
     UserAccountNotFound,
+
+    #[msg("Number of winners does not match length of winners array")]
+    NumberOfWinnersMismatch,
+
+    #[msg("Escrow not empty")]
+    EscrowNotEmpty,
 }

--- a/programs/ralli-bet/programs/ralli-bet/src/errors.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/errors.rs
@@ -163,12 +163,16 @@ pub enum RalliError {
 
     #[msg("Empty picks provided")]
     EmptyPicks,
+
     #[msg("Picks do not match the expected line")]
     PicksLinesMismatch,
+
     #[msg("Invalid line account provided")]
     InvalidLineAccount,
+
     #[msg("Line already started")]
     LineAlreadyStarted,
+
     #[msg("Invalid remaining accounts count")]
     InvalidRemainingAccountsCount,
 
@@ -180,6 +184,37 @@ pub enum RalliError {
 
     #[msg("Too many lines")]
     TooManyLines,
+
     #[msg("Line mismatch")]
     LineMismatch,
+
+    #[msg("Only admin can resolve games")]
+    UnauthorizedGameResolution,
+
+    #[msg("Game does not have any lines")]
+    NoLinesInGame,
+
+    #[msg("Line accounts are missing")]
+    MissingLineAccounts,
+
+    #[msg("Line is yet to be resolved")]
+    LineNotResolved,
+
+    #[msg("Unrealistic fees")]
+    ExcessiveFee,
+
+    #[msg("Bet account should be valid")]
+    InvalidBetAccount,
+
+    #[msg("This bet is not involved in thisgame")]
+    BetNotInGame,
+
+    #[msg("This bet does not belong to this user")]
+    InvalidBetPlayer,
+
+    #[msg("No users in the game")]
+    NoPlayersInGame,
+
+    #[msg("User account is not available")]
+    UserAccountNotFound,
 }

--- a/programs/ralli-bet/programs/ralli-bet/src/errors.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/errors.rs
@@ -226,4 +226,7 @@ pub enum RalliError {
 
     #[msg("Escrow not empty")]
     EscrowNotEmpty,
+
+    #[msg("Number of winners expected does not match number of winners")]
+    NumberOfWinnersExpectedMismatch,
 }

--- a/programs/ralli-bet/programs/ralli-bet/src/instructions/mod.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/instructions/mod.rs
@@ -3,8 +3,7 @@ pub mod create_line;
 pub mod join_game;
 pub mod resolve_line;
 pub mod submit_bet;
-// pub mod lock_game;
-// pub mod resolve_game;
+pub mod resolve_game;
 pub mod cancel_game;
 pub mod withdraw_submission;
 
@@ -13,7 +12,6 @@ pub use create_line::*;
 pub use join_game::*;
 pub use resolve_line::*;
 pub use submit_bet::*;
-// pub use lock_game::*;
-// pub use resolve_game::*;
+pub use resolve_game::*;
 pub use cancel_game::*;
 pub use withdraw_submission::*;

--- a/programs/ralli-bet/programs/ralli-bet/src/instructions/resolve_game.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/instructions/resolve_game.rs
@@ -48,7 +48,11 @@ impl<'info> ResolveGame<'info> {
         );
 
         // Ensure game is Open
-        require_eq!(game.status, GameStatus::Open, RalliError::GameAlreadyResolved);
+        require_eq!(
+            game.status,
+            GameStatus::Open,
+            RalliError::GameAlreadyResolved
+        );
 
         require!(!game.involved_lines.is_empty(), RalliError::NoLinesInGame);
 
@@ -68,12 +72,9 @@ impl<'info> ResolveGame<'info> {
         for line_account_info in line_accounts.iter() {
             let line_account = Account::<Line>::try_from(line_account_info)
                 .map_err(|_| error!(RalliError::InvalidLineAccount))?;
-            
-            require!(
-                line_account.result.is_some(),
-                RalliError::LineNotResolved
-            );
-            
+
+            require!(line_account.result.is_some(), RalliError::LineNotResolved);
+
             require!(
                 game.involved_lines.contains(&line_account_info.key()),
                 RalliError::LineNotInGame
@@ -83,15 +84,17 @@ impl<'info> ResolveGame<'info> {
         // Calculate winners and losers
         let mut winners: Vec<Pubkey> = Vec::new();
         let mut all_bets: Vec<Account<Bet>> = Vec::new();
+        let mut correct_picks_count_for_winners = 0;
+        let mut number_of_winners = 0;
 
         // Load and validate all bet accounts
         for (_i, bet_account_info) in bet_accounts.iter().enumerate() {
             let bet_account = Account::<Bet>::try_from(bet_account_info)
                 .map_err(|_| error!(RalliError::InvalidBetAccount))?;
-            
+
             // Verify bet belongs to this game
             require_eq!(bet_account.game, game.key(), RalliError::BetNotInGame);
-            
+
             // Verify bet belongs to a user in the game
             require!(
                 game.users.contains(&bet_account.player),
@@ -102,12 +105,12 @@ impl<'info> ResolveGame<'info> {
             let mut correct_count = 0;
             for pick in &bet_account.picks {
                 // Find the corresponding line
-                if let Some(line_account_info) = line_accounts.iter()
-                    .find(|line| line.key() == pick.line_id) {
-                    
+                if let Some(line_account_info) =
+                    line_accounts.iter().find(|line| line.key() == pick.line_id)
+                {
                     let line_account = Account::<Line>::try_from(line_account_info)
                         .map_err(|_| error!(RalliError::InvalidLineAccount))?;
-                    
+
                     if let Some(result) = &line_account.result {
                         if *result == pick.direction {
                             correct_count += 1;
@@ -117,8 +120,14 @@ impl<'info> ResolveGame<'info> {
             }
 
             // Player wins if they got ALL picks correct
-            if correct_count == game.number_of_lines {
+            if correct_count == correct_picks_count_for_winners {
                 winners.push(bet_account.player);
+                number_of_winners += 1;
+            } else if correct_count > correct_picks_count_for_winners {
+                correct_picks_count_for_winners = correct_count;
+                winners.clear();
+                winners.push(bet_account.player);
+                number_of_winners = 1;
             }
 
             all_bets.push(bet_account);
@@ -129,6 +138,10 @@ impl<'info> ResolveGame<'info> {
         let number_of_losers = total_players - number_of_winners;
 
         require!(total_players > 0, RalliError::NoPlayersInGame);
+        require!(
+            number_of_winners == winners.len(),
+            RalliError::NumberOfWinnersMismatch
+        );
 
         let game_key = game.key();
 
@@ -138,17 +151,14 @@ impl<'info> ResolveGame<'info> {
             for user_key in &game.users {
                 let transfer_instruction = Transfer {
                     from: game_escrow.to_account_info(),
-                    to: remaining_accounts.iter()
+                    to: remaining_accounts
+                        .iter()
                         .find(|acc| acc.key() == *user_key)
                         .ok_or(RalliError::UserAccountNotFound)?
                         .clone(),
                 };
 
-                let seeds = &[
-                    b"escrow",
-                    game_key.as_ref(),
-                    &[game_escrow.bump],
-                ];
+                let seeds = &[b"escrow", game_key.as_ref(), &[game_escrow.bump]];
                 let signer_seeds = &[&seeds[..]];
 
                 let cpi_ctx = CpiContext::new_with_signer(
@@ -157,66 +167,6 @@ impl<'info> ResolveGame<'info> {
                     signer_seeds,
                 );
                 transfer(cpi_ctx, game.entry_fee)?;
-            }
-
-            game_escrow.total_amount = 0;
-            game.status = GameStatus::Resolved;
-            return Ok(());
-        }
-
-        // Handle edge case where no one wins
-        if number_of_winners == 0 {
-            // Calculate total fees (from all players)
-            let total_fees = (game_escrow.total_amount as u128 * fee_percentage as u128) / 10000u128;
-            let total_fees = total_fees as u64;
-
-            // Transfer fees to treasury if any
-            if total_fees > 0 {
-                let transfer_instruction = Transfer {
-                    from: game_escrow.to_account_info(),
-                    to: self.treasury.to_account_info(),
-                };
-
-                let seeds = &[
-                    b"escrow",
-                    game_key.as_ref(),
-                    &[game_escrow.bump],
-                ];
-                let signer_seeds = &[&seeds[..]];
-
-                let cpi_ctx = CpiContext::new_with_signer(
-                    self.system_program.to_account_info(),
-                    transfer_instruction,
-                    signer_seeds,
-                );
-                transfer(cpi_ctx, total_fees)?;
-            }
-
-            // Return remaining money equally to all players
-            let remaining_per_player = (game_escrow.total_amount - total_fees) / total_players as u64;
-            
-            for user_key in &game.users {
-                let transfer_instruction = Transfer {
-                    from: game_escrow.to_account_info(),
-                    to: remaining_accounts.iter()
-                        .find(|acc| acc.key() == *user_key)
-                        .ok_or(RalliError::UserAccountNotFound)?
-                        .clone(),
-                };
-
-                let seeds = &[
-                    b"escrow",
-                    game_key.as_ref(),
-                    &[game_escrow.bump],
-                ];
-                let signer_seeds = &[&seeds[..]];
-
-                let cpi_ctx = CpiContext::new_with_signer(
-                    self.system_program.to_account_info(),
-                    transfer_instruction,
-                    signer_seeds,
-                );
-                transfer(cpi_ctx, remaining_per_player)?;
             }
 
             game_escrow.total_amount = 0;
@@ -233,11 +183,13 @@ impl<'info> ResolveGame<'info> {
         let fee_from_losers = fee_from_losers as u64;
         let net_losers_pool = losers_pool - fee_from_losers;
         let winnings_per_winner = net_losers_pool / number_of_winners as u64;
+        let remainder_to_treasury = net_losers_pool % number_of_winners as u64;
         let total_per_winner = game.entry_fee + winnings_per_winner;
 
         // Transfer winnings to each winner
         for winner_key in &winners {
-            let winner_account = remaining_accounts.iter()
+            let winner_account = remaining_accounts
+                .iter()
                 .find(|acc| acc.key() == *winner_key)
                 .ok_or(RalliError::UserAccountNotFound)?;
 
@@ -246,11 +198,7 @@ impl<'info> ResolveGame<'info> {
                 to: winner_account.to_account_info(),
             };
 
-            let seeds = &[
-                b"escrow",
-                game_key.as_ref(),
-                &[game_escrow.bump],
-            ];
+            let seeds = &[b"escrow", game_key.as_ref(), &[game_escrow.bump]];
             let signer_seeds = &[&seeds[..]];
 
             let cpi_ctx = CpiContext::new_with_signer(
@@ -259,20 +207,18 @@ impl<'info> ResolveGame<'info> {
                 signer_seeds,
             );
             transfer(cpi_ctx, total_per_winner)?;
+            game_escrow.total_amount -= total_per_winner;
         }
 
-        // Transfer fees to treasury if any
-        if fee_from_losers > 0 {
+        // Transfer fees and remainder to treasury if any
+        let total_treasury_amount = fee_from_losers + remainder_to_treasury;
+        if total_treasury_amount > 0 {
             let transfer_instruction = Transfer {
                 from: game_escrow.to_account_info(),
                 to: self.treasury.to_account_info(),
             };
 
-            let seeds = &[
-                b"escrow",
-                game_key.as_ref(),
-                &[game_escrow.bump],
-            ];
+            let seeds = &[b"escrow", game_key.as_ref(), &[game_escrow.bump]];
             let signer_seeds = &[&seeds[..]];
 
             let cpi_ctx = CpiContext::new_with_signer(
@@ -280,12 +226,15 @@ impl<'info> ResolveGame<'info> {
                 transfer_instruction,
                 signer_seeds,
             );
-            transfer(cpi_ctx, fee_from_losers)?;
+            transfer(cpi_ctx, total_treasury_amount)?;
         }
 
         // Update escrow balance
-        let total_distributed = (total_per_winner * number_of_winners as u64) + fee_from_losers;
+        let total_distributed =
+            (total_per_winner * number_of_winners as u64) + total_treasury_amount;
         game_escrow.total_amount -= total_distributed;
+
+        require!(game_escrow.total_amount == 0, RalliError::EscrowNotEmpty);
 
         // Mark game as resolved
         game.status = GameStatus::Resolved;

--- a/programs/ralli-bet/programs/ralli-bet/src/instructions/resolve_game.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/instructions/resolve_game.rs
@@ -1,65 +1,303 @@
-use anchor_lang::prelude::*;
-use crate::state::*;
+use crate::constants::*;
 use crate::errors::RalliError;
-use std::collections::HashMap;
+use crate::state::*;
+use anchor_lang::prelude::*;
+use anchor_lang::system_program::{transfer, Transfer};
 
 #[derive(Accounts)]
 pub struct ResolveGame<'info> {
-    #[account(mut, seeds = [b"game", game.game_id.to_le_bytes().as_ref()], bump = game.bump, has_one = creator)]
+    #[account(mut)]
+    pub admin: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"game", game.game_id.to_le_bytes().as_ref()],
+        bump = game.bump
+    )]
     pub game: Account<'info, Game>,
 
-    #[account(mut, seeds = [b"escrow", game.key().as_ref()], bump = game_escrow.bump)]
+    #[account(
+        mut,
+        seeds = [b"escrow", game.key().as_ref()],
+        bump = game_escrow.bump
+    )]
     pub game_escrow: Account<'info, GameEscrow>,
 
-    #[account(init, payer = creator, space = GameResult::MAX_SIZE, seeds = [b"result", game.key().as_ref()], bump)]
-    pub game_result: Account<'info, GameResult>,
-
+    /// CHECK: Treasury account to receive fees (can be any account)
     #[account(mut)]
-    pub creator: Signer<'info>,
+    pub treasury: AccountInfo<'info>,
+
     pub system_program: Program<'info, System>,
-    // Pass the Line accounts in remaining_accounts
 }
 
-pub fn handler(ctx: Context<ResolveGame>) -> Result<()> {
-    let game = &mut ctx.accounts.game;
-    let game_escrow = &mut ctx.accounts.game_escrow;
-    let game_result = &mut ctx.accounts.game_result;
-    let clock = Clock::get()?;
+impl<'info> ResolveGame<'info> {
+    pub fn resolve_game(
+        &mut self,
+        fee_percentage: u16,
+        remaining_accounts: &'info [AccountInfo<'info>],
+    ) -> Result<()> {
+        let game = &mut self.game;
+        let game_escrow = &mut self.game_escrow;
+        let admin = &self.admin;
 
-    require_eq!(game.status, GameStatus::Locked, RalliError::GameNotLocked);
+        // Only admin can resolve games
+        require_eq!(
+            admin.key(),
+            ADMIN_PUBLIC_KEY,
+            RalliError::UnauthorizedGameResolution
+        );
 
-    let lines: Vec<Account<Line>> = ctx.remaining_accounts.iter().map(|acc| Account::try_from(acc).unwrap()).collect();
+        // Ensure game is Open
+        require_eq!(game.status, GameStatus::Open, RalliError::GameAlreadyResolved);
 
-    // In a real implementation, iterate through all Bet accounts for this game
-    // and use the `lines` vector to calculate correct picks.
-    // This is a simplified representation.
+        require!(!game.involved_lines.is_empty(), RalliError::NoLinesInGame);
 
-    game_result.game = game.key();
-    game_result.resolved = true;
-    game_result.winners = Vec::new();
-    game_result.highest_correct = 0;
-    game_result.total_pool = game_escrow.total_amount;
-    game_result.resolved_at = clock.unix_timestamp;
-    game_result.bump = ctx.bumps.game_result;
+        // Validate fee percentage
+        require!(fee_percentage <= 1000, RalliError::ExcessiveFee);
 
-    game.status = GameStatus::Resolved;
+        let bet_accounts = &remaining_accounts[..game.users.len()];
+        let line_accounts = &remaining_accounts[game.users.len()..];
 
-    msg!("Game {} resolved", game.game_id);
-    Ok(())
-}
+        require_eq!(
+            line_accounts.len(),
+            game.involved_lines.len(),
+            RalliError::MissingLineAccounts
+        );
 
-pub fn calculate_correct_picks(picks: &[Pick], lines: &[Account<Line>]) -> u8 {
-    let mut correct = 0;
-    let line_map: HashMap<Pubkey, &Account<Line>> = lines.iter().map(|line| (line.key(), line)).collect();
+        // Verify all lines are resolved
+        for line_account_info in line_accounts.iter() {
+            let line_account = Account::<Line>::try_from(line_account_info)
+                .map_err(|_| error!(RalliError::InvalidLineAccount))?;
+            
+            require!(
+                line_account.result.is_some(),
+                RalliError::LineNotResolved
+            );
+            
+            require!(
+                game.involved_lines.contains(&line_account_info.key()),
+                RalliError::LineNotInGame
+            );
+        }
 
-    for pick in picks {
-        if let Some(line) = line_map.get(&pick.line_id) {
-            if let Some(result) = &line.result {
-                if pick.direction == *result {
-                    correct += 1;
+        // Calculate winners and losers
+        let mut winners: Vec<Pubkey> = Vec::new();
+        let mut all_bets: Vec<Account<Bet>> = Vec::new();
+
+        // Load and validate all bet accounts
+        for (_i, bet_account_info) in bet_accounts.iter().enumerate() {
+            let bet_account = Account::<Bet>::try_from(bet_account_info)
+                .map_err(|_| error!(RalliError::InvalidBetAccount))?;
+            
+            // Verify bet belongs to this game
+            require_eq!(bet_account.game, game.key(), RalliError::BetNotInGame);
+            
+            // Verify bet belongs to a user in the game
+            require!(
+                game.users.contains(&bet_account.player),
+                RalliError::InvalidBetPlayer
+            );
+
+            // Calculate correct picks for this bet
+            let mut correct_count = 0;
+            for pick in &bet_account.picks {
+                // Find the corresponding line
+                if let Some(line_account_info) = line_accounts.iter()
+                    .find(|line| line.key() == pick.line_id) {
+                    
+                    let line_account = Account::<Line>::try_from(line_account_info)
+                        .map_err(|_| error!(RalliError::InvalidLineAccount))?;
+                    
+                    if let Some(result) = &line_account.result {
+                        if *result == pick.direction {
+                            correct_count += 1;
+                        }
+                    }
                 }
             }
+
+            // Player wins if they got ALL picks correct
+            if correct_count == game.number_of_lines {
+                winners.push(bet_account.player);
+            }
+
+            all_bets.push(bet_account);
         }
+
+        let total_players = game.users.len();
+        let number_of_winners = winners.len();
+        let number_of_losers = total_players - number_of_winners;
+
+        require!(total_players > 0, RalliError::NoPlayersInGame);
+
+        let game_key = game.key();
+
+        // Handle edge case where everyone wins
+        if number_of_winners == total_players {
+            // Just return everyone's money, no fees
+            for user_key in &game.users {
+                let transfer_instruction = Transfer {
+                    from: game_escrow.to_account_info(),
+                    to: remaining_accounts.iter()
+                        .find(|acc| acc.key() == *user_key)
+                        .ok_or(RalliError::UserAccountNotFound)?
+                        .clone(),
+                };
+
+                let seeds = &[
+                    b"escrow",
+                    game_key.as_ref(),
+                    &[game_escrow.bump],
+                ];
+                let signer_seeds = &[&seeds[..]];
+
+                let cpi_ctx = CpiContext::new_with_signer(
+                    self.system_program.to_account_info(),
+                    transfer_instruction,
+                    signer_seeds,
+                );
+                transfer(cpi_ctx, game.entry_fee)?;
+            }
+
+            game_escrow.total_amount = 0;
+            game.status = GameStatus::Resolved;
+            return Ok(());
+        }
+
+        // Handle edge case where no one wins
+        if number_of_winners == 0 {
+            // Calculate total fees (from all players)
+            let total_fees = (game_escrow.total_amount as u128 * fee_percentage as u128) / 10000u128;
+            let total_fees = total_fees as u64;
+
+            // Transfer fees to treasury if any
+            if total_fees > 0 {
+                let transfer_instruction = Transfer {
+                    from: game_escrow.to_account_info(),
+                    to: self.treasury.to_account_info(),
+                };
+
+                let seeds = &[
+                    b"escrow",
+                    game_key.as_ref(),
+                    &[game_escrow.bump],
+                ];
+                let signer_seeds = &[&seeds[..]];
+
+                let cpi_ctx = CpiContext::new_with_signer(
+                    self.system_program.to_account_info(),
+                    transfer_instruction,
+                    signer_seeds,
+                );
+                transfer(cpi_ctx, total_fees)?;
+            }
+
+            // Return remaining money equally to all players
+            let remaining_per_player = (game_escrow.total_amount - total_fees) / total_players as u64;
+            
+            for user_key in &game.users {
+                let transfer_instruction = Transfer {
+                    from: game_escrow.to_account_info(),
+                    to: remaining_accounts.iter()
+                        .find(|acc| acc.key() == *user_key)
+                        .ok_or(RalliError::UserAccountNotFound)?
+                        .clone(),
+                };
+
+                let seeds = &[
+                    b"escrow",
+                    game_key.as_ref(),
+                    &[game_escrow.bump],
+                ];
+                let signer_seeds = &[&seeds[..]];
+
+                let cpi_ctx = CpiContext::new_with_signer(
+                    self.system_program.to_account_info(),
+                    transfer_instruction,
+                    signer_seeds,
+                );
+                transfer(cpi_ctx, remaining_per_player)?;
+            }
+
+            game_escrow.total_amount = 0;
+            game.status = GameStatus::Resolved;
+            return Ok(());
+        }
+
+        // Formulas Used!
+        // Winner gets: entry_fee + (entry_fee * number_of_losers * (1 - fee)) / number_of_winners
+        // Treasury gets: (entry_fee * number_of_losers * fee) / number_of_winners per winner
+
+        let losers_pool = game.entry_fee * number_of_losers as u64;
+        let fee_from_losers = (losers_pool as u128 * fee_percentage as u128) / 10000u128;
+        let fee_from_losers = fee_from_losers as u64;
+        let net_losers_pool = losers_pool - fee_from_losers;
+        let winnings_per_winner = net_losers_pool / number_of_winners as u64;
+        let total_per_winner = game.entry_fee + winnings_per_winner;
+
+        // Transfer winnings to each winner
+        for winner_key in &winners {
+            let winner_account = remaining_accounts.iter()
+                .find(|acc| acc.key() == *winner_key)
+                .ok_or(RalliError::UserAccountNotFound)?;
+
+            let transfer_instruction = Transfer {
+                from: game_escrow.to_account_info(),
+                to: winner_account.to_account_info(),
+            };
+
+            let seeds = &[
+                b"escrow",
+                game_key.as_ref(),
+                &[game_escrow.bump],
+            ];
+            let signer_seeds = &[&seeds[..]];
+
+            let cpi_ctx = CpiContext::new_with_signer(
+                self.system_program.to_account_info(),
+                transfer_instruction,
+                signer_seeds,
+            );
+            transfer(cpi_ctx, total_per_winner)?;
+        }
+
+        // Transfer fees to treasury if any
+        if fee_from_losers > 0 {
+            let transfer_instruction = Transfer {
+                from: game_escrow.to_account_info(),
+                to: self.treasury.to_account_info(),
+            };
+
+            let seeds = &[
+                b"escrow",
+                game_key.as_ref(),
+                &[game_escrow.bump],
+            ];
+            let signer_seeds = &[&seeds[..]];
+
+            let cpi_ctx = CpiContext::new_with_signer(
+                self.system_program.to_account_info(),
+                transfer_instruction,
+                signer_seeds,
+            );
+            transfer(cpi_ctx, fee_from_losers)?;
+        }
+
+        // Update escrow balance
+        let total_distributed = (total_per_winner * number_of_winners as u64) + fee_from_losers;
+        game_escrow.total_amount -= total_distributed;
+
+        // Mark game as resolved
+        game.status = GameStatus::Resolved;
+
+        msg!(
+            "Game {} resolved - Winners: {}, Losers: {}, Fees collected: {} lamports",
+            game.game_id,
+            number_of_winners,
+            number_of_losers,
+            fee_from_losers
+        );
+
+        Ok(())
     }
-    correct
 }

--- a/programs/ralli-bet/programs/ralli-bet/src/instructions/resolve_line.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/instructions/resolve_line.rs
@@ -43,6 +43,12 @@ impl<'info> ResolveLine<'info> {
 
         // Ensure line has started (can only resolve after start time)
         let current_time = Clock::get()?.unix_timestamp;
+        msg!("current_time: {}", current_time);
+        msg!("line.starts_at: {}", line.starts_at);
+        msg!(
+            "current_time - line.starts_at: {}",
+            current_time - line.starts_at
+        );
         require!(current_time >= line.starts_at, RalliError::LineNotStarted);
 
         // this verifies that predicted vs actual reflects the direction passed

--- a/programs/ralli-bet/programs/ralli-bet/src/instructions/submit_bet.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/instructions/submit_bet.rs
@@ -1,4 +1,3 @@
-use crate::constants::*;
 use crate::errors::RalliError;
 use crate::state::*;
 use anchor_lang::prelude::*;
@@ -64,7 +63,7 @@ impl<'info> SubmitBet<'info> {
 
             // Check if this line is part of the game
             let line_pubkey = line_account_info.key();
-            if (!game.involved_lines.contains(&line_pubkey)) {
+            if !game.involved_lines.contains(&line_pubkey) {
                 game.involved_lines.push(line_pubkey);
             }
 

--- a/programs/ralli-bet/programs/ralli-bet/src/lib.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/lib.rs
@@ -91,9 +91,13 @@ pub mod ralli_bet {
     pub fn resolve_game<'info>(
         ctx: Context<'_, '_, 'info, 'info, ResolveGame<'info>>,
         fee_percentage: u16,
+        number_of_winners_expected: u16,
     ) -> Result<()> {
-        ctx.accounts
-            .resolve_game(fee_percentage, ctx.remaining_accounts)
+        ctx.accounts.resolve_game(
+            fee_percentage,
+            number_of_winners_expected,
+            ctx.remaining_accounts,
+        )
     }
 
     // pub fn submit_bet(ctx: Context<SubmitBet>, picks: Vec<state::Pick>) -> Result<()> {

--- a/programs/ralli-bet/programs/ralli-bet/src/lib.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/lib.rs
@@ -77,6 +77,17 @@ pub mod ralli_bet {
             .submit_bet(picks, &ctx.bumps, remaining_accounts)
     }
 
+    pub fn resolve_line(ctx: Context<ResolveLine>, result: Direction, actual_value: f64) -> Result<()> {
+    ctx.accounts.resolve_line(result, actual_value)
+    }
+
+    pub fn resolve_game<'info>(
+        ctx: Context<'_, '_, 'info, 'info, ResolveGame<'info>>, 
+        fee_percentage: u16
+    ) -> Result<()> {
+        ctx.accounts.resolve_game(fee_percentage, ctx.remaining_accounts)
+    }
+
     // pub fn submit_bet(ctx: Context<SubmitBet>, picks: Vec<state::Pick>) -> Result<()> {
     //     instructions::submit_bet::handler(ctx, picks)
     // }

--- a/programs/ralli-bet/programs/ralli-bet/src/lib.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/lib.rs
@@ -88,15 +88,12 @@ pub mod ralli_bet {
             .submit_bet(picks, &ctx.bumps, remaining_accounts)
     }
 
-    pub fn resolve_line(ctx: Context<ResolveLine>, result: Direction, actual_value: f64) -> Result<()> {
-    ctx.accounts.resolve_line(result, actual_value)
-    }
-
     pub fn resolve_game<'info>(
-        ctx: Context<'_, '_, 'info, 'info, ResolveGame<'info>>, 
-        fee_percentage: u16
+        ctx: Context<'_, '_, 'info, 'info, ResolveGame<'info>>,
+        fee_percentage: u16,
     ) -> Result<()> {
-        ctx.accounts.resolve_game(fee_percentage, ctx.remaining_accounts)
+        ctx.accounts
+            .resolve_game(fee_percentage, ctx.remaining_accounts)
     }
 
     // pub fn submit_bet(ctx: Context<SubmitBet>, picks: Vec<state::Pick>) -> Result<()> {

--- a/programs/ralli-bet/programs/ralli-bet/src/state/game.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/state/game.rs
@@ -4,6 +4,7 @@ use anchor_lang::prelude::*;
 #[derive(InitSpace)]
 pub struct Game {
     pub game_id: u64,
+    pub mint: Pubkey,
     pub first_line_starts_at: i64,
     pub creator: Pubkey,
     pub admin: Pubkey,

--- a/programs/ralli-bet/tests/ralli-bet.ts
+++ b/programs/ralli-bet/tests/ralli-bet.ts
@@ -1713,8 +1713,13 @@ describe("RalliBet Comprehensive Tests", () => {
     let newBet1Game2: PublicKey;
     let newBet2Game2: PublicKey;
 
+    let newBet1Game3: PublicKey;
+    let newBet2Game3: PublicKey;
+    let newBet3Game3: PublicKey;
+    let newBet4Game3: PublicKey;
+
     before(async () => {
-      let newStartsSoonRaw = Date.now() + 12000;
+      let newStartsSoonRaw = Date.now() + 20000;
       let newStartsSoon = new BN(Math.floor(newStartsSoonRaw / 1000));
       const [newLine1] = PublicKey.findProgramAddressSync(
         [Buffer.from("line"), newLineId1.toArrayLike(Buffer, "le", 8)],
@@ -2170,6 +2175,289 @@ describe("RalliBet Comprehensive Tests", () => {
       newGameEscrow2PK = newGameEscrow2;
       newGameVault2PK = newGameVault2;
 
+      const newGameId3 = new BN(2003);
+
+      const [newGame3] = PublicKey.findProgramAddressSync(
+        [Buffer.from("game"), newGameId3.toArrayLike(Buffer, "le", 8)],
+        program.programId
+      );
+
+      const [newGameEscrow3] = PublicKey.findProgramAddressSync(
+        [Buffer.from("escrow"), newGame3.toBuffer()],
+        program.programId
+      );
+
+      const newGameVault3 = getAssociatedTokenAddressSync(mint, newGame3, true);
+
+      const txCreateGame3 = await program.methods
+        .createGame(
+          newGameId3,
+          maxUsers,
+          entryFee,
+          numberOfLines,
+          provider.wallet.publicKey
+        )
+        .accountsPartial({
+          creator: user1.publicKey,
+          game: newGame3,
+          gameEscrow: newGameEscrow3,
+          gameVault: newGameVault3,
+          mint: mint,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      const txJoinGame3User1 = await program.methods
+        .joinGame()
+        .accountsPartial({
+          user: user1.publicKey,
+          game: newGame3,
+          gameEscrow: newGameEscrow3,
+          gameVault: newGameVault3,
+          mint: mint,
+          userTokens: user1TokenAccount,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      [newBet1Game3] = PublicKey.findProgramAddressSync(
+        [Buffer.from("bet"), newGame3.toBuffer(), user1.publicKey.toBuffer()],
+        program.programId
+      );
+
+      const txSubmitBet1Game3 = await program.methods
+        .submitBet([
+          {
+            lineId: newLine1PK,
+            direction: { over: {} },
+          },
+          {
+            lineId: newLine2PK,
+            direction: { over: {} },
+          },
+          {
+            lineId: newLine3PK,
+            direction: { under: {} },
+          },
+        ])
+        .accountsPartial({
+          user: user1.publicKey,
+          game: newGame3,
+          bet: newBet1Game3,
+        })
+        .signers([user1])
+        .remainingAccounts([
+          {
+            pubkey: newLine1PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine2PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine3PK,
+            isWritable: false,
+            isSigner: false,
+          },
+        ])
+        .rpc();
+
+      const txJoinGame3User2 = await program.methods
+        .joinGame()
+        .accountsPartial({
+          user: user2.publicKey,
+          game: newGame3,
+          gameEscrow: newGameEscrow3,
+          gameVault: newGameVault3,
+          mint: mint,
+          userTokens: user2TokenAccount,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user2])
+        .rpc();
+
+      [newBet2Game3] = PublicKey.findProgramAddressSync(
+        [Buffer.from("bet"), newGame3.toBuffer(), user2.publicKey.toBuffer()],
+        program.programId
+      );
+
+      const txSubmitBet2Game3 = await program.methods
+        .submitBet([
+          {
+            lineId: newLine1PK,
+            direction: { under: {} },
+          },
+          {
+            lineId: newLine2PK,
+            direction: { under: {} },
+          },
+          {
+            lineId: newLine3PK,
+            direction: { under: {} },
+          },
+        ])
+        .accountsPartial({
+          user: user2.publicKey,
+          game: newGame3,
+          bet: newBet2Game3,
+        })
+        .signers([user2])
+        .remainingAccounts([
+          {
+            pubkey: newLine1PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine2PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine3PK,
+            isWritable: false,
+            isSigner: false,
+          },
+        ])
+        .rpc();
+
+      const txJoinGame3User3 = await program.methods
+        .joinGame()
+        .accountsPartial({
+          user: user3.publicKey,
+          game: newGame3,
+          gameEscrow: newGameEscrow3,
+          gameVault: newGameVault3,
+          mint: mint,
+          userTokens: user3TokenAccount,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user3])
+        .rpc();
+
+      [newBet3Game3] = PublicKey.findProgramAddressSync(
+        [Buffer.from("bet"), newGame3.toBuffer(), user3.publicKey.toBuffer()],
+        program.programId
+      );
+
+      const txSubmitBet3Game3 = await program.methods
+        .submitBet([
+          {
+            lineId: newLine1PK,
+            direction: { under: {} },
+          },
+          {
+            lineId: newLine2PK,
+            direction: { over: {} },
+          },
+          {
+            lineId: newLine3PK,
+            direction: { over: {} },
+          },
+        ])
+        .accountsPartial({
+          user: user3.publicKey,
+          game: newGame3,
+          bet: newBet3Game3,
+        })
+        .signers([user3])
+        .remainingAccounts([
+          {
+            pubkey: newLine1PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine2PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine3PK,
+            isWritable: false,
+            isSigner: false,
+          },
+        ])
+        .rpc();
+
+      const txJoinGame3User4 = await program.methods
+        .joinGame()
+        .accountsPartial({
+          user: keypair.publicKey,
+          game: newGame3,
+          gameEscrow: newGameEscrow3,
+          gameVault: newGameVault3,
+          mint: mint,
+          userTokens: providerTokenAccount,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([keypair])
+        .rpc();
+
+      [newBet4Game3] = PublicKey.findProgramAddressSync(
+        [Buffer.from("bet"), newGame3.toBuffer(), keypair.publicKey.toBuffer()],
+        program.programId
+      );
+
+      const txSubmitBet4Game3 = await program.methods
+        .submitBet([
+          {
+            lineId: newLine1PK,
+            direction: { under: {} },
+          },
+          {
+            lineId: newLine2PK,
+            direction: { over: {} },
+          },
+          {
+            lineId: newLine3PK,
+            direction: { under: {} },
+          },
+        ])
+        .accountsPartial({
+          user: keypair.publicKey,
+          game: newGame3,
+          bet: newBet4Game3,
+        })
+        .signers([keypair])
+        .remainingAccounts([
+          {
+            pubkey: newLine1PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine2PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine3PK,
+            isWritable: false,
+            isSigner: false,
+          },
+        ])
+        .rpc();
+
+      newGame3PK = newGame3;
+      newGameEscrow1PK = newGameEscrow1;
+      newGameVault1PK = newGameVault1;
+
       const timeToWait = newStartsSoonRaw - Date.now();
 
       await new Promise((resolve) => setTimeout(resolve, timeToWait + 2000));
@@ -2422,6 +2710,140 @@ describe("RalliBet Comprehensive Tests", () => {
       expect(
         user2BalanceAfter.value.uiAmount! - user2BalanceBefore.value.uiAmount!
       ).to.equal(entryFeeRaw / 10 ** MINT_DECIMALS);
+    });
+
+    it("should successfully resolve game between four users where three win, no fees", async () => {
+      const user1BalanceBefore = await connection.getTokenAccountBalance(
+        user1TokenAccount
+      );
+      const user2BalanceBefore = await connection.getTokenAccountBalance(
+        user2TokenAccount
+      );
+      const user3BalanceBefore = await connection.getTokenAccountBalance(
+        user3TokenAccount
+      );
+      const user4BalanceBefore = await connection.getTokenAccountBalance(
+        providerTokenAccount
+      );
+      const treasuryBalanceBefore = await connection.getTokenAccountBalance(
+        treasuryTokenAccount
+      );
+
+      // Debug: Print all account addresses
+      const accounts = {
+        admin: provider.wallet.publicKey,
+        treasury: treasury.publicKey,
+        treasuryVault: treasuryTokenAccount,
+        mint: mint,
+        game: newGame3PK,
+        gameEscrow: newGameEscrow3PK,
+        gameVault: newGameVault3PK,
+        systemProgram: SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+      };
+
+      const tx = await program.methods
+        .resolveGame(0, 3)
+        .accountsPartial(accounts)
+        .signers([keypair])
+        .remainingAccounts([
+          {
+            pubkey: newBet1Game3,
+            isWritable: true,
+            isSigner: false,
+          },
+          {
+            pubkey: newBet2Game3,
+            isWritable: true,
+            isSigner: false,
+          },
+          {
+            pubkey: newBet3Game3,
+            isWritable: true,
+            isSigner: false,
+          },
+
+          {
+            pubkey: newBet4Game3,
+            isWritable: true,
+            isSigner: false,
+          },
+          {
+            pubkey: user1TokenAccount,
+            isWritable: true,
+            isSigner: false,
+          },
+          {
+            pubkey: user2TokenAccount,
+            isWritable: true,
+            isSigner: false,
+          },
+          {
+            pubkey: user3TokenAccount,
+            isWritable: true,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine1PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine2PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine3PK,
+            isWritable: false,
+            isSigner: false,
+          },
+        ])
+        .rpc();
+
+      const gameAccount = await program.account.game.fetch(newGame1PK);
+      expect(gameAccount.status).to.deep.equal({ resolved: {} });
+      const gameEscrowAccount = await program.account.gameEscrow.fetch(
+        newGameEscrow1PK
+      );
+      expect(gameEscrowAccount.totalAmount.toNumber()).to.equal(0);
+
+      const treasuryBalanceAfter = await connection.getTokenAccountBalance(
+        treasuryTokenAccount
+      );
+      expect(
+        treasuryBalanceAfter.value.uiAmount! -
+          treasuryBalanceBefore.value.uiAmount!
+      ).to.not.equal(0);
+
+      const user1BalanceAfter = await connection.getTokenAccountBalance(
+        user1TokenAccount
+      );
+      expect(
+        user1BalanceAfter.value.uiAmount! - user1BalanceBefore.value.uiAmount!
+      ).to.be.closeTo(
+        (entryFeeRaw + entryFeeRaw / 3) / 10 ** MINT_DECIMALS,
+        0.000001
+      );
+      const user2BalanceAfter = await connection.getTokenAccountBalance(
+        user2TokenAccount
+      );
+      expect(
+        user2BalanceAfter.value.uiAmount! - user2BalanceBefore.value.uiAmount!
+      ).to.be.closeTo(
+        (entryFeeRaw + entryFeeRaw / 3) / 10 ** MINT_DECIMALS,
+        0.000001
+      );
+      const user3BalanceAfter = await connection.getTokenAccountBalance(
+        user3TokenAccount
+      );
+      expect(
+        user3BalanceAfter.value.uiAmount! - user3BalanceBefore.value.uiAmount!
+      ).to.be.closeTo(
+        (entryFeeRaw + entryFeeRaw / 3) / 10 ** MINT_DECIMALS,
+        0.000001
+      );
     });
   });
 });

--- a/programs/ralli-bet/tests/ralli-bet.ts
+++ b/programs/ralli-bet/tests/ralli-bet.ts
@@ -1718,8 +1718,13 @@ describe("RalliBet Comprehensive Tests", () => {
     let newBet3Game3: PublicKey;
     let newBet4Game3: PublicKey;
 
+    let newBet1Game4: PublicKey;
+    let newBet2Game4: PublicKey;
+    let newBet3Game4: PublicKey;
+    let newBet4Game4: PublicKey;
+
     before(async () => {
-      let newStartsSoonRaw = Date.now() + 20000;
+      let newStartsSoonRaw = Date.now() + 30000;
       let newStartsSoon = new BN(Math.floor(newStartsSoonRaw / 1000));
       const [newLine1] = PublicKey.findProgramAddressSync(
         [Buffer.from("line"), newLineId1.toArrayLike(Buffer, "le", 8)],
@@ -2458,6 +2463,328 @@ describe("RalliBet Comprehensive Tests", () => {
       newGameEscrow1PK = newGameEscrow1;
       newGameVault1PK = newGameVault1;
 
+      const newGameId4 = new BN(2004);
+
+      const [newGame4] = PublicKey.findProgramAddressSync(
+        [Buffer.from("game"), newGameId4.toArrayLike(Buffer, "le", 8)],
+        program.programId
+      );
+
+      const [newGameEscrow4] = PublicKey.findProgramAddressSync(
+        [Buffer.from("escrow"), newGame4.toBuffer()],
+        program.programId
+      );
+
+      const newGameVault4 = getAssociatedTokenAddressSync(mint, newGame4, true);
+
+      const txCreateGame4 = await program.methods
+        .createGame(
+          newGameId4,
+          maxUsers,
+          entryFee,
+          numberOfLines,
+          provider.wallet.publicKey
+        )
+        .accountsPartial({
+          creator: user1.publicKey,
+          game: newGame4,
+          gameEscrow: newGameEscrow4,
+          gameVault: newGameVault4,
+          mint: mint,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      const txJoinGame4User1 = await program.methods
+        .joinGame()
+        .accountsPartial({
+          user: user1.publicKey,
+          game: newGame4,
+          gameEscrow: newGameEscrow4,
+          gameVault: newGameVault4,
+          mint: mint,
+          userTokens: user1TokenAccount,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      [newBet1Game4] = PublicKey.findProgramAddressSync(
+        [Buffer.from("bet"), newGame4.toBuffer(), user1.publicKey.toBuffer()],
+        program.programId
+      );
+
+      const txSubmitBet1Game4 = await program.methods
+        .submitBet([
+          {
+            lineId: newLine1PK,
+            direction: { over: {} },
+          },
+          {
+            lineId: newLine2PK,
+            direction: { over: {} },
+          },
+          {
+            lineId: newLine3PK,
+            direction: { under: {} },
+          },
+        ])
+        .accountsPartial({
+          user: user1.publicKey,
+          game: newGame4,
+          bet: newBet1Game4,
+        })
+        .signers([user1])
+        .remainingAccounts([
+          {
+            pubkey: newLine1PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine2PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine3PK,
+            isWritable: false,
+            isSigner: false,
+          },
+        ])
+        .rpc();
+
+      const txJoinGame4User2 = await program.methods
+        .joinGame()
+        .accountsPartial({
+          user: user2.publicKey,
+          game: newGame4,
+          gameEscrow: newGameEscrow4,
+          gameVault: newGameVault4,
+          mint: mint,
+          userTokens: user2TokenAccount,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user2])
+        .rpc();
+
+      [newBet2Game4] = PublicKey.findProgramAddressSync(
+        [Buffer.from("bet"), newGame4.toBuffer(), user2.publicKey.toBuffer()],
+        program.programId
+      );
+
+      const txSubmitBet2Game4 = await program.methods
+        .submitBet([
+          {
+            lineId: newLine1PK,
+            direction: { under: {} },
+          },
+          {
+            lineId: newLine2PK,
+            direction: { under: {} },
+          },
+          {
+            lineId: newLine3PK,
+            direction: { under: {} },
+          },
+        ])
+        .accountsPartial({
+          user: user2.publicKey,
+          game: newGame4,
+          bet: newBet2Game4,
+        })
+        .signers([user2])
+        .remainingAccounts([
+          {
+            pubkey: newLine1PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine2PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine3PK,
+            isWritable: false,
+            isSigner: false,
+          },
+        ])
+        .rpc();
+
+      const txJoinGame4User3 = await program.methods
+        .joinGame()
+        .accountsPartial({
+          user: user3.publicKey,
+          game: newGame4,
+          gameEscrow: newGameEscrow4,
+          gameVault: newGameVault4,
+          mint: mint,
+          userTokens: user3TokenAccount,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user3])
+        .rpc();
+
+      [newBet3Game4] = PublicKey.findProgramAddressSync(
+        [Buffer.from("bet"), newGame4.toBuffer(), user3.publicKey.toBuffer()],
+        program.programId
+      );
+
+      const txSubmitBet3Game4 = await program.methods
+        .submitBet([
+          {
+            lineId: newLine1PK,
+            direction: { under: {} },
+          },
+          {
+            lineId: newLine2PK,
+            direction: { over: {} },
+          },
+          {
+            lineId: newLine3PK,
+            direction: { over: {} },
+          },
+        ])
+        .accountsPartial({
+          user: user3.publicKey,
+          game: newGame4,
+          bet: newBet3Game4,
+        })
+        .signers([user3])
+        .remainingAccounts([
+          {
+            pubkey: newLine1PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine2PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine3PK,
+            isWritable: false,
+            isSigner: false,
+          },
+        ])
+        .rpc();
+
+      const txJoinGame4User4 = await program.methods
+        .joinGame()
+        .accountsPartial({
+          user: keypair.publicKey,
+          game: newGame4,
+          gameEscrow: newGameEscrow4,
+          gameVault: newGameVault4,
+          mint: mint,
+          userTokens: providerTokenAccount,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([keypair])
+        .rpc();
+
+      [newBet4Game4] = PublicKey.findProgramAddressSync(
+        [Buffer.from("bet"), newGame4.toBuffer(), keypair.publicKey.toBuffer()],
+        program.programId
+      );
+
+      const txSubmitBet4Game4 = await program.methods
+        .submitBet([
+          {
+            lineId: newLine1PK,
+            direction: { under: {} },
+          },
+          {
+            lineId: newLine2PK,
+            direction: { over: {} },
+          },
+          {
+            lineId: newLine3PK,
+            direction: { under: {} },
+          },
+        ])
+        .accountsPartial({
+          user: keypair.publicKey,
+          game: newGame4,
+          bet: newBet4Game4,
+        })
+        .signers([keypair])
+        .remainingAccounts([
+          {
+            pubkey: newLine1PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine2PK,
+            isWritable: false,
+            isSigner: false,
+          },
+          {
+            pubkey: newLine3PK,
+            isWritable: false,
+            isSigner: false,
+          },
+        ])
+        .rpc();
+
+      newGame4PK = newGame4;
+      newGameEscrow4PK = newGameEscrow4;
+      newGameVault4PK = newGameVault4;
+
+      const newGameId5 = new BN(2005);
+
+      const [newGame5] = PublicKey.findProgramAddressSync(
+        [Buffer.from("game"), newGameId5.toArrayLike(Buffer, "le", 8)],
+        program.programId
+      );
+
+      const [newGameEscrow5] = PublicKey.findProgramAddressSync(
+        [Buffer.from("escrow"), newGame5.toBuffer()],
+        program.programId
+      );
+
+      const newGameVault5 = getAssociatedTokenAddressSync(mint, newGame5, true);
+
+      const txCreateGame5 = await program.methods
+        .createGame(
+          newGameId5,
+          maxUsers,
+          entryFee,
+          numberOfLines,
+          provider.wallet.publicKey
+        )
+        .accountsPartial({
+          creator: user1.publicKey,
+          game: newGame5,
+          gameEscrow: newGameEscrow5,
+          gameVault: newGameVault5,
+          mint: mint,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      newGame5PK = newGame5;
+      newGameEscrow5PK = newGameEscrow5;
+      newGameVault5PK = newGameVault5;
+
       const timeToWait = newStartsSoonRaw - Date.now();
 
       await new Promise((resolve) => setTimeout(resolve, timeToWait + 2000));
@@ -2613,6 +2940,62 @@ describe("RalliBet Comprehensive Tests", () => {
       expect(
         user2BalanceAfter.value.uiAmount! - user2BalanceBefore.value.uiAmount!
       ).to.equal(0);
+    });
+
+    it("should fail to resolve game that is already resolved", async () => {
+      try {
+        const tx = await program.methods
+          .resolveGame(entryFeePercentage, 1)
+          .accountsPartial({
+            admin: provider.wallet.publicKey,
+            treasury: treasury.publicKey,
+            treasuryVault: treasuryTokenAccount,
+            mint: mint,
+            game: newGame1PK,
+            gameEscrow: newGameEscrow1PK,
+            gameVault: newGameVault1PK,
+            systemProgram: SystemProgram.programId,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          })
+          .signers([keypair])
+          .remainingAccounts([
+            {
+              pubkey: newBet1Game1,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet2Game1,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user1TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine1PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine2PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine3PK,
+              isWritable: false,
+              isSigner: false,
+            },
+          ])
+          .rpc();
+        expect.fail("Should have failed with GameAlreadyResolved");
+      } catch (error) {
+        expect(error.toString()).to.include("Error Code: GameAlreadyResolved");
+      }
     });
 
     it("should successfully resolve game between two users where there is as draw", async () => {
@@ -2844,6 +3227,701 @@ describe("RalliBet Comprehensive Tests", () => {
         (entryFeeRaw + entryFeeRaw / 3) / 10 ** MINT_DECIMALS,
         0.000001
       );
+    });
+
+    it("should fail to resolve game if not admin", async () => {
+      try {
+        const tx = await program.methods
+          .resolveGame(0, 3)
+          .accountsPartial({
+            admin: user1.publicKey,
+            treasury: treasury.publicKey,
+            treasuryVault: treasuryTokenAccount,
+            mint: mint,
+            game: newGame3PK,
+            gameEscrow: newGameEscrow3PK,
+            gameVault: newGameVault3PK,
+            systemProgram: SystemProgram.programId,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          })
+          .signers([user1])
+          .remainingAccounts([
+            {
+              pubkey: newBet1Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet2Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet3Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newBet4Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user1TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user2TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user3TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine1PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine2PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine3PK,
+              isWritable: false,
+              isSigner: false,
+            },
+          ])
+          .rpc();
+        expect.fail("Should have failed with UnauthorizedGameResolution");
+      } catch (error) {
+        expect(error.toString()).to.include(
+          "Error Code: UnauthorizedGameResolution"
+        );
+      }
+    });
+
+    it("should fail to resolve game if fee is too high", async () => {
+      try {
+        const tx = await program.methods
+          .resolveGame(1001, 3)
+          .accountsPartial({
+            admin: keypair.publicKey,
+            treasury: treasury.publicKey,
+            treasuryVault: treasuryTokenAccount,
+            mint: mint,
+            game: newGame4PK,
+            gameEscrow: newGameEscrow4PK,
+            gameVault: newGameVault4PK,
+            systemProgram: SystemProgram.programId,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          })
+          .signers([keypair])
+          .remainingAccounts([
+            {
+              pubkey: newBet1Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet2Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet3Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newBet4Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user1TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user2TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user3TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine1PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine2PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine3PK,
+              isWritable: false,
+              isSigner: false,
+            },
+          ])
+          .rpc();
+        expect.fail("Should have failed with ExcessiveFee");
+      } catch (error) {
+        expect(error.toString()).to.include("Error Code: ExcessiveFee");
+      }
+    });
+
+    it("should fail to resolve game if line account missing", async () => {
+      try {
+        const tx = await program.methods
+          .resolveGame(entryFeePercentage, 3)
+          .accountsPartial({
+            admin: keypair.publicKey,
+            treasury: treasury.publicKey,
+            treasuryVault: treasuryTokenAccount,
+            mint: mint,
+            game: newGame4PK,
+            gameEscrow: newGameEscrow4PK,
+            gameVault: newGameVault4PK,
+            systemProgram: SystemProgram.programId,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          })
+          .signers([keypair])
+          .remainingAccounts([
+            {
+              pubkey: newBet1Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet2Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet3Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newBet4Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user1TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user2TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user3TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine2PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine3PK,
+              isWritable: false,
+              isSigner: false,
+            },
+          ])
+          .rpc();
+        expect.fail("Should have failed with MissingLineAccounts");
+      } catch (error) {
+        expect(error.toString()).to.include("Error Code: MissingLineAccounts");
+      }
+    });
+
+    it("should fail to resolve game if line account is invalid", async () => {
+      try {
+        const tx = await program.methods
+          .resolveGame(entryFeePercentage, 3)
+          .accountsPartial({
+            admin: keypair.publicKey,
+            treasury: treasury.publicKey,
+            treasuryVault: treasuryTokenAccount,
+            mint: mint,
+            game: newGame4PK,
+            gameEscrow: newGameEscrow4PK,
+            gameVault: newGameVault4PK,
+            systemProgram: SystemProgram.programId,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          })
+          .signers([keypair])
+          .remainingAccounts([
+            {
+              pubkey: newBet1Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet2Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet3Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newBet4Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user1TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user2TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user3TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: providerTokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine2PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine3PK,
+              isWritable: false,
+              isSigner: false,
+            },
+          ])
+          .rpc();
+        expect.fail("Should have failed with InvalidLineAccount");
+      } catch (error) {
+        expect(error.toString()).to.include("Error Code: InvalidLineAccount");
+      }
+    });
+
+    it("should fail to resolve game if line account is not resolved", async () => {
+      try {
+        const tx = await program.methods
+          .resolveGame(entryFeePercentage, 3)
+          .accountsPartial({
+            admin: keypair.publicKey,
+            treasury: treasury.publicKey,
+            treasuryVault: treasuryTokenAccount,
+            mint: mint,
+            game: newGame4PK,
+            gameEscrow: newGameEscrow4PK,
+            gameVault: newGameVault4PK,
+            systemProgram: SystemProgram.programId,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          })
+          .signers([keypair])
+          .remainingAccounts([
+            {
+              pubkey: newBet1Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet2Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet3Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newBet4Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user1TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user2TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user3TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newLine1PK,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine2PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: line3PK,
+              isWritable: false,
+              isSigner: false,
+            },
+          ])
+          .rpc();
+        expect.fail("Should have failed with LineNotResolved");
+      } catch (error) {
+        expect(error.toString()).to.include("Error Code: LineNotResolved");
+      }
+    });
+
+    it("should fail to resolve game if line account is not in game", async () => {
+      try {
+        const tx = await program.methods
+          .resolveGame(entryFeePercentage, 3)
+          .accountsPartial({
+            admin: keypair.publicKey,
+            treasury: treasury.publicKey,
+            treasuryVault: treasuryTokenAccount,
+            mint: mint,
+            game: newGame4PK,
+            gameEscrow: newGameEscrow4PK,
+            gameVault: newGameVault4PK,
+            systemProgram: SystemProgram.programId,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          })
+          .signers([keypair])
+          .remainingAccounts([
+            {
+              pubkey: newBet1Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet2Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet3Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newBet4Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user1TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user2TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user3TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newLine1PK,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine2PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine5PK,
+              isWritable: false,
+              isSigner: false,
+            },
+          ])
+          .rpc();
+        expect.fail("Should have failed with LineNotInGame");
+      } catch (error) {
+        expect(error.toString()).to.include("Error Code: LineNotInGame");
+      }
+    });
+    it("should fail to resolve game if bet account is not valid", async () => {
+      try {
+        const tx = await program.methods
+          .resolveGame(entryFeePercentage, 3)
+          .accountsPartial({
+            admin: keypair.publicKey,
+            treasury: treasury.publicKey,
+            treasuryVault: treasuryTokenAccount,
+            mint: mint,
+            game: newGame4PK,
+            gameEscrow: newGameEscrow4PK,
+            gameVault: newGameVault4PK,
+            systemProgram: SystemProgram.programId,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          })
+          .signers([keypair])
+          .remainingAccounts([
+            {
+              pubkey: line1PK,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet2Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet3Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newBet4Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user1TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user2TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user3TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newLine1PK,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine2PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine3PK,
+              isWritable: false,
+              isSigner: false,
+            },
+          ])
+          .rpc();
+        expect.fail("Should have failed with InvalidBetAccount");
+      } catch (error) {
+        expect(error.toString()).to.include("Error Code: InvalidBetAccount");
+      }
+    });
+
+    it("should fail to resolve game if bet account is not valid", async () => {
+      try {
+        const tx = await program.methods
+          .resolveGame(entryFeePercentage, 3)
+          .accountsPartial({
+            admin: keypair.publicKey,
+            treasury: treasury.publicKey,
+            treasuryVault: treasuryTokenAccount,
+            mint: mint,
+            game: newGame4PK,
+            gameEscrow: newGameEscrow4PK,
+            gameVault: newGameVault4PK,
+            systemProgram: SystemProgram.programId,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          })
+          .signers([keypair])
+          .remainingAccounts([
+            {
+              pubkey: newBet1Game1,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet2Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet3Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newBet4Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user1TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user2TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user3TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newLine1PK,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine2PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine3PK,
+              isWritable: false,
+              isSigner: false,
+            },
+          ])
+          .rpc();
+        expect.fail("Should have failed with BetNotInGame");
+      } catch (error) {
+        expect(error.toString()).to.include("Error Code: BetNotInGame");
+      }
+    });
+
+    it("should fail to resolve game if no bets have been made", async () => {
+      try {
+        const tx = await program.methods
+          .resolveGame(entryFeePercentage, 0)
+          .accountsPartial({
+            admin: keypair.publicKey,
+            treasury: treasury.publicKey,
+            treasuryVault: treasuryTokenAccount,
+            mint: mint,
+            game: newGame5PK,
+            gameEscrow: newGameEscrow5PK,
+            gameVault: newGameVault5PK,
+            systemProgram: SystemProgram.programId,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          })
+          .signers([keypair])
+          .remainingAccounts([
+            {
+              pubkey: newBet1Game1,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet2Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newBet3Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newBet4Game3,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user1TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user2TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: user3TokenAccount,
+              isWritable: true,
+              isSigner: false,
+            },
+
+            {
+              pubkey: newLine1PK,
+              isWritable: true,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine2PK,
+              isWritable: false,
+              isSigner: false,
+            },
+            {
+              pubkey: newLine3PK,
+              isWritable: false,
+              isSigner: false,
+            },
+          ])
+          .rpc();
+        expect.fail("Should have failed with NoLinesInGame");
+      } catch (error) {
+        expect(error.toString()).to.include("Error Code: NoLinesInGame");
+      }
     });
   });
 });


### PR DESCRIPTION
Created tests for:
- 1v1, 1 player wins, 1% fee
- 1v1, tie, 1% fee (no fee applied)
- 4 person, 3 winners, no fee, overflow is sent to treasury

And failure tests for every error in the instruction I could figure out a way to hit. I couldn't think of error cases to hit these errors:
- RalliError::InvalidBetPlayer
- RalliError::InvalidLineAccount (2nd instance)
- RalliError::NoPlayersInGame
- RalliError::NumberOfWinnersMismatch
- RalliError::NumberOfWinnersExpectedMismatch
- RalliError::EscrowNotEmpty

