### PR TITLE
 Ensure-Consistent-AthleteIDs

### DIFF
--- a/packages/db/src/seeds/athletes.seed.ts
+++ b/packages/db/src/seeds/athletes.seed.ts
@@ -4,8 +4,23 @@ import * as schema from "@repo/db";
 import { preSeasonAthletes } from "./data/athletes/preseason-athletes";
 
 export const athletesData: (typeof athletes.$inferInsert)[] = preSeasonAthletes;
+// Replace first 5 athlete ids matching those in linesData
 
 export const seedAthletes = async (db: NodePgDatabase<typeof schema>) => {
+  const fixedAthleteIds = [
+    //keeping athlete ids the same for now - for data consistency in seeding
+    "1aae0249-6b34-41a3-87b9-5131b91fb9af",
+    "8bd865b0-22dc-42b5-aa73-d37dd3729765",
+    "e91e546f-75a0-4bfb-9bb5-3e21d2258edf",
+    "9528068f-57b5-4380-bc04-f4238057b440",
+    "17b27fd9-8ebe-4ce7-9e84-cb34714386a6",
+  ];
+
+  for (let i = 0; i < 5 && i < athletesData.length; i++) {
+    if (athletesData?.[i]) {
+      athletesData[i]!.id = fixedAthleteIds[i];
+    }
+  }
   await db.insert(athletes).values(athletesData).onConflictDoNothing();
   console.log("✅ Athletes seeded");
 };

--- a/packages/db/src/seeds/lines.seed.ts
+++ b/packages/db/src/seeds/lines.seed.ts
@@ -4,54 +4,54 @@ import * as schema from "@repo/db";
 
 export const linesData: (typeof lines.$inferInsert)[] = [
   {
-    id: "550e8400-e29b-41d4-a716-446655440060",
-    athleteId: "550e8400-e29b-41d4-a716-446655440030", // Josh Allen
+    id: "a1f5c8b2-1234-4d8a-9b3e-111111111111",
+    athleteId: "1aae0249-6b34-41a3-87b9-5131b91fb9af", // Tim Smith
+    statId: 25, // total_tackles
+    matchupId: "550e8400-e29b-41d4-a716-446655440050",
+    predictedValue: "4.5",
+    actualValue: "6",
+    isHigher: true,
+    createdAt: new Date("2025-08-05T10:00:00Z"),
+  },
+  {
+    id: "b7d4e9c3-5678-4e9f-8c75-222222222222",
+    athleteId: "8bd865b0-22dc-42b5-aa73-d37dd3729765", // Grover Stewart
+    statId: 26, // sacks
+    matchupId: "550e8400-e29b-41d4-a716-446655440051",
+    predictedValue: "0.5",
+    actualValue: "1",
+    isHigher: true,
+    createdAt: new Date("2025-08-05T10:00:00Z"),
+  },
+  {
+    id: "c62f0b74-9abc-463d-81a3-333333333333",
+    athleteId: "e91e546f-75a0-4bfb-9bb5-3e21d2258edf", // Anthony Richardson Sr.
     statId: 1, // passing_yards
-    matchupId: "550e8400-e29b-41d4-a716-446655440050", // Chiefs vs Ravens
-    predictedValue: "285.5",
-    actualValue: "291", // Final actual value from match
+    matchupId: "550e8400-e29b-41d4-a716-446655440050",
+    predictedValue: "245.5",
+    actualValue: "261",
     isHigher: true,
-    createdAt: new Date("2024-09-01T10:00:00Z"),
+    createdAt: new Date("2025-08-05T11:00:00Z"),
   },
   {
-    id: "550e8400-e29b-41d4-a716-446655440061",
-    athleteId: "550e8400-e29b-41d4-a716-446655440036", // Travis Kelce
-    statId: 2, // receiving_touchdowns
-    matchupId: "550e8400-e29b-41d4-a716-446655440050", // Chiefs vs Ravens
+    id: "d94caf85-3456-4fef-90d1-444444444444",
+    athleteId: "9528068f-57b5-4380-bc04-f4238057b440", // Michael Pittman Jr.
+    statId: 14, // receiving_yards
+    matchupId: "550e8400-e29b-41d4-a716-446655440051",
+    predictedValue: "78.0",
+    actualValue: null,
+    isHigher: null,
+    createdAt: new Date("2025-08-05T11:00:00Z"),
+  },
+  {
+    id: "e374c296-7890-4edb-91af-555555555555",
+    athleteId: "17b27fd9-8ebe-4ce7-9e84-cb34714386a6", // Spencer Shrader
+    statId: 28, // field_goals_made
+    matchupId: "550e8400-e29b-41d4-a716-446655440050",
     predictedValue: "1.5",
-    actualValue: "2",
-    isHigher: true,
-    createdAt: new Date("2024-09-01T10:00:00Z"),
-  },
-  {
-    id: "550e8400-e29b-41d4-a716-446655440062",
-    athleteId: "550e8400-e29b-41d4-a716-446655440030", // Josh Allen
-    statId: 3, // fantasy_points
-    matchupId: "550e8400-e29b-41d4-a716-446655440051", // Bills vs Dolphins
-    predictedValue: "24.0",
-    actualValue: "26.12",
-    isHigher: true,
-    createdAt: new Date("2024-09-02T14:00:00Z"),
-  },
-  {
-    id: "550e8400-e29b-41d4-a716-446655440063",
-    athleteId: "550e8400-e29b-41d4-a716-446655440032", // Christian McCaffrey
-    statId: 4, // rushing_yards
-    matchupId: "550e8400-e29b-41d4-a716-446655440052", // 49ers vs Rams
-    predictedValue: "120",
     actualValue: null,
     isHigher: null,
-    createdAt: new Date("2024-09-10T09:00:00Z"),
-  },
-  {
-    id: "550e8400-e29b-41d4-a716-446655440064",
-    athleteId: "550e8400-e29b-41d4-a716-446655440035", // Cooper Kupp
-    statId: 5, // receiving_yards
-    matchupId: "550e8400-e29b-41d4-a716-446655440052", // 49ers vs Rams
-    predictedValue: "95",
-    actualValue: null,
-    isHigher: null,
-    createdAt: new Date("2024-09-10T09:10:00Z"),
+    createdAt: new Date("2025-08-05T12:00:00Z"),
   },
 ];
 

--- a/packages/db/src/seeds/matchups.seed.ts
+++ b/packages/db/src/seeds/matchups.seed.ts
@@ -1,83 +1,90 @@
-import { NodePgDatabase } from 'drizzle-orm/node-postgres';
-import { matchups, matchup_performance } from '@repo/db';
-import * as schema from '@repo/db';
+import { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { matchups, matchup_performance } from "@repo/db";
+import * as schema from "@repo/db";
 
 export const matchupsData: (typeof matchups.$inferInsert)[] = [
   {
-    id: '550e8400-e29b-41d4-a716-446655440050',
-    gameDate: '2024-09-08', // ✅ String format, not Date object
-    homeTeam: 'Kansas City Chiefs',
-    awayTeam: 'Baltimore Ravens',
-    status: 'finished',
+    id: "550e8400-e29b-41d4-a716-446655440050",
+    gameDate: "2024-09-08", // ✅ String format, not Date object
+    homeTeam: "Kansas City Chiefs",
+    awayTeam: "Baltimore Ravens",
+    status: "finished",
     scoreHome: 27,
     scoreAway: 20,
   },
   {
-    id: '550e8400-e29b-41d4-a716-446655440051',
-    gameDate: '2024-09-08', // ✅ String format
-    homeTeam: 'Buffalo Bills',
-    awayTeam: 'Miami Dolphins',
-    status: 'finished',
+    id: "550e8400-e29b-41d4-a716-446655440051",
+    gameDate: "2024-09-08", // ✅ String format
+    homeTeam: "Buffalo Bills",
+    awayTeam: "Miami Dolphins",
+    status: "finished",
     scoreHome: 31,
     scoreAway: 17,
   },
   {
-    id: '550e8400-e29b-41d4-a716-446655440052',
-    gameDate: '2024-09-15', // ✅ String format
-    homeTeam: 'San Francisco 49ers',
-    awayTeam: 'Los Angeles Rams',
-    status: 'in_progress',
+    id: "550e8400-e29b-41d4-a716-446655440052",
+    gameDate: "2024-09-15", // ✅ String format
+    homeTeam: "San Francisco 49ers",
+    awayTeam: "Los Angeles Rams",
+    status: "in_progress",
     scoreHome: 14,
     scoreAway: 7,
   },
   {
-    id: '550e8400-e29b-41d4-a716-446655440053',
-    gameDate: '2024-09-22', // ✅ String format
-    homeTeam: 'Miami Dolphins',
-    awayTeam: 'Kansas City Chiefs',
-    status: 'scheduled',
+    id: "550e8400-e29b-41d4-a716-446655440053",
+    gameDate: "2024-09-22", // ✅ String format
+    homeTeam: "Miami Dolphins",
+    awayTeam: "Kansas City Chiefs",
+    status: "scheduled",
     scoreHome: null,
     scoreAway: null,
+  },
+  {
+    id: "550e8400-e29b-41d4-a716-446655440060",
+    gameDate: "2025-08-05",
+    homeTeam: "Indianapolis Colts",
+    awayTeam: "Houston Texans",
+    status: "finished",
+    scoreHome: 30,
+    scoreAway: 24,
   },
 ];
 
 export const matchupPerformanceData = [
-  // Patrick Mahomes vs Ravens
+  // Anthony Richardson Sr. vs Texans
   {
-    id: '550e8400-e29b-41d4-a716-446655440060',
-    matchupId: '550e8400-e29b-41d4-a716-446655440050',
-    athleteId: '550e8400-e29b-41d4-a716-446655440031',
+    id: "a9a1e36c-7efa-4a8f-a079-111111111111",
+    matchupId: "550e8400-e29b-41d4-a716-446655440060",
+    athleteId: "e91e546f-75a0-4bfb-9bb5-3e21d2258edf", // Anthony Richardson Sr.
     stats: {
-      passing_yards: 291,
-      passing_touchdowns: 3,
-      rushing_yards: 15,
-      rushing_touchdowns: 0,
-      fantasy_points: 23.46,
-    },
-  },
-  // Travis Kelce vs Ravens
-  {
-    id: '550e8400-e29b-41d4-a716-446655440061',
-    matchupId: '550e8400-e29b-41d4-a716-446655440050',
-    athleteId: '550e8400-e29b-41d4-a716-446655440036',
-    stats: {
-      receiving_yards: 103,
-      receiving_touchdowns: 2,
-      receptions: 7,
-      fantasy_points: 22.3,
-    },
-  },
-  // Josh Allen vs Dolphins
-  {
-    id: '550e8400-e29b-41d4-a716-446655440062',
-    matchupId: '550e8400-e29b-41d4-a716-446655440051',
-    athleteId: '550e8400-e29b-41d4-a716-446655440030',
-    stats: {
-      passing_yards: 320,
+      passing_yards: 261,
       passing_touchdowns: 2,
-      rushing_yards: 58,
+      rushing_yards: 41,
       rushing_touchdowns: 1,
-      fantasy_points: 26.12,
+      fantasy_points: 23.7,
+    },
+  },
+  // Michael Pittman Jr. vs Texans
+  {
+    id: "b2c5f4dd-4aed-462a-b2e7-222222222222",
+    matchupId: "550e8400-e29b-41d4-a716-446655440060",
+    athleteId: "9528068f-57b5-4380-bc04-f4238057b440", // Michael Pittman Jr.
+    stats: {
+      receiving_yards: 83,
+      receiving_touchdowns: 1,
+      receptions: 6,
+      fantasy_points: 17.3,
+    },
+  },
+  // Tim Smith vs Texans (defensive)
+  {
+    id: "c3d7e8aa-1cbe-4f50-9a1b-333333333333",
+    matchupId: "550e8400-e29b-41d4-a716-446655440060",
+    athleteId: "1aae0249-6b34-41a3-87b9-5131b91fb9af", // Tim Smith
+    stats: {
+      total_tackles: 6,
+      sacks: 0.5,
+      fumbles: 1,
     },
   },
 ];
@@ -88,5 +95,5 @@ export const seedMatchups = async (db: NodePgDatabase<typeof schema>) => {
     .insert(matchup_performance)
     .values(matchupPerformanceData)
     .onConflictDoNothing();
-  console.log('✅ Matchups and performances seeded');
+  console.log("✅ Matchups and performances seeded");
 };

--- a/packages/db/src/seeds/predictions.seed.ts
+++ b/packages/db/src/seeds/predictions.seed.ts
@@ -6,7 +6,7 @@ export const predictionsData: (typeof predictions.$inferInsert)[] = [
   {
     id: "550e8400-e29b-41d4-a716-446655440100",
     participantId: "550e8400-e29b-41d4-a716-446655440090",
-    lineId: "550e8400-e29b-41d4-a716-446655440060", // Corresponds to Patrick Mahomes passing yards line
+    lineId: "a1f5c8b2-1234-4d8a-9b3e-111111111111", // Tim Smith line (updated)
     predictedDirection: "higher",
     isCorrect: true,
     createdAt: new Date("2024-09-01T11:00:00Z"),
@@ -14,7 +14,7 @@ export const predictionsData: (typeof predictions.$inferInsert)[] = [
   {
     id: "550e8400-e29b-41d4-a716-446655440101",
     participantId: "550e8400-e29b-41d4-a716-446655440090",
-    lineId: "550e8400-e29b-41d4-a716-446655440061", // Travis Kelce receiving touchdowns line
+    lineId: "b7d4e9c3-5678-4e9f-8c75-222222222222", // Grover Stewart line (updated)
     predictedDirection: "higher",
     isCorrect: true,
     createdAt: new Date("2024-09-01T11:05:00Z"),
@@ -22,7 +22,7 @@ export const predictionsData: (typeof predictions.$inferInsert)[] = [
   {
     id: "550e8400-e29b-41d4-a716-446655440102",
     participantId: "550e8400-e29b-41d4-a716-446655440091",
-    lineId: "550e8400-e29b-41d4-a716-446655440060",
+    lineId: "c62f0b74-9abc-463d-81a3-333333333333", // Anthony Richardson Sr. line (updated)
     predictedDirection: "lower",
     isCorrect: false,
     createdAt: new Date("2024-09-01T11:10:00Z"),
@@ -30,34 +30,18 @@ export const predictionsData: (typeof predictions.$inferInsert)[] = [
   {
     id: "550e8400-e29b-41d4-a716-446655440103",
     participantId: "550e8400-e29b-41d4-a716-446655440093",
-    lineId: "550e8400-e29b-41d4-a716-446655440062", // Josh Allen fantasy points line
+    lineId: "d94caf85-3456-4fef-90d1-444444444444", // Michael Pittman Jr. line (updated)
     predictedDirection: "higher",
-    isCorrect: true,
+    isCorrect: null,
     createdAt: new Date("2024-09-02T15:00:00Z"),
   },
   {
     id: "550e8400-e29b-41d4-a716-446655440104",
     participantId: "550e8400-e29b-41d4-a716-446655440094",
-    lineId: "550e8400-e29b-41d4-a716-446655440062",
+    lineId: "e374c296-7890-4edb-91af-555555555555", // Spencer Shrader line (updated)
     predictedDirection: "lower",
-    isCorrect: false,
+    isCorrect: null,
     createdAt: new Date("2024-09-02T15:10:00Z"),
-  },
-  {
-    id: "550e8400-e29b-41d4-a716-446655440105",
-    participantId: "550e8400-e29b-41d4-a716-446655440095",
-    lineId: "550e8400-e29b-41d4-a716-446655440063", // Christian McCaffrey rushing yards line
-    predictedDirection: "higher",
-    isCorrect: null,
-    createdAt: new Date("2024-09-10T10:00:00Z"),
-  },
-  {
-    id: "550e8400-e29b-41d4-a716-446655440106",
-    participantId: "550e8400-e29b-41d4-a716-446655440096",
-    lineId: "550e8400-e29b-41d4-a716-446655440064", // Cooper Kupp receiving yards line
-    predictedDirection: "higher",
-    isCorrect: null,
-    createdAt: new Date("2024-09-10T10:15:00Z"),
   },
 ];
 


### PR DESCRIPTION
This PR implements a fix to explicitly set and keep the first 5 athletes’ IDs consistent and aligned with expected UUIDs. This ensures referential integrity across related data and avoids random ID assignments on every seed.