### PR TITLE
Prakharsharma2506/ral 139 create update line instruction

### DIFF
--- a/programs/ralli-bet/programs/ralli-bet/src/errors.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/errors.rs
@@ -229,4 +229,10 @@ pub enum RalliError {
 
     #[msg("Number of winners expected does not match number of winners")]
     NumberOfWinnersExpectedMismatch,
+
+    #[msg("Only admin can update the lines")]
+    UnauthorizedLineUpdate,
+
+    #[msg("Predicted value should be different for update")]
+    SamePredictedValue,
 }

--- a/programs/ralli-bet/programs/ralli-bet/src/instructions/mod.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/instructions/mod.rs
@@ -6,6 +6,7 @@ pub mod submit_bet;
 pub mod resolve_game;
 pub mod cancel_game;
 pub mod withdraw_submission;
+pub mod update_line;
 
 pub use create_game::*;
 pub use create_line::*;
@@ -15,3 +16,4 @@ pub use submit_bet::*;
 pub use resolve_game::*;
 pub use cancel_game::*;
 pub use withdraw_submission::*;
+pub use update_line::*;

--- a/programs/ralli-bet/programs/ralli-bet/src/instructions/update_line.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/instructions/update_line.rs
@@ -1,0 +1,59 @@
+use crate::constants::*;
+use crate::errors::RalliError;
+use crate::state::*;
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct UpdateLine<'info> {
+    #[account(mut)]
+    pub admin: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"line", line.key().as_ref()],
+        bump = line.bump
+    )]
+    pub line: Account<'info, Line>,
+}
+
+impl<'info> UpdateLine<'info> {
+    pub fn update_line(&mut self, new_predicted_value: f64) -> Result<()> {
+        let admin = &self.admin;
+        let line = &mut self.line;
+
+        // Only admin can update lines
+        require!(
+            is_admin(&admin.key()),
+            RalliError::UnauthorizedLineUpdate
+        );
+
+        // Ensure line hasn't been resolved yet
+        require!(line.result.is_none(), RalliError::LineAlreadyResolved);
+
+        // Ensure line hasn't started yet
+        let current_time = Clock::get()?.unix_timestamp;
+        require!(current_time < line.starts_at, RalliError::LineAlreadyStarted);
+
+        require!(new_predicted_value > 0.0, RalliError::InvalidPredictedValue);
+
+        // Ensure the new value is actually different
+        require!(
+            (line.predicted_value - new_predicted_value).abs() > f64::EPSILON,
+            RalliError::SamePredictedValue
+        );
+
+        let old_predicted_value = line.predicted_value;
+
+        // Update now
+        line.predicted_value = new_predicted_value;
+
+        msg!(
+            "Updated line {} - Changed predicted value from {} to {}",
+            line.key(),
+            old_predicted_value,
+            new_predicted_value
+        );
+
+        Ok(())
+    }
+}

--- a/programs/ralli-bet/programs/ralli-bet/src/instructions/update_line.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/instructions/update_line.rs
@@ -17,7 +17,7 @@ pub struct UpdateLine<'info> {
 }
 
 impl<'info> UpdateLine<'info> {
-    pub fn update_line(&mut self, new_predicted_value: f64) -> Result<()> {
+    pub fn update_line(&mut self, new_predicted_value: f64, should_refund_bettors: bool) -> Result<()> {
         let admin = &self.admin;
         let line = &mut self.line;
 
@@ -46,12 +46,14 @@ impl<'info> UpdateLine<'info> {
 
         // Update now
         line.predicted_value = new_predicted_value;
+        line.should_refund_bettors = should_refund_bettors;
 
         msg!(
-            "Updated line {} - Changed predicted value from {} to {}",
+            "Updated line {} - Changed predicted value from {} to {}, should_refund_bettors: {}",
             line.key(),
             old_predicted_value,
-            new_predicted_value
+            new_predicted_value,
+            should_refund_bettors
         );
 
         Ok(())

--- a/programs/ralli-bet/programs/ralli-bet/src/lib.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/lib.rs
@@ -100,6 +100,10 @@ pub mod ralli_bet {
         )
     }
 
+    pub fn update_line(ctx: Context<UpdateLine>, new_predicted_value: f64) -> Result<()> {
+        ctx.accounts.update_line(new_predicted_value)
+    }
+
     // pub fn submit_bet(ctx: Context<SubmitBet>, picks: Vec<state::Pick>) -> Result<()> {
     //     instructions::submit_bet::handler(ctx, picks)
     // }

--- a/programs/ralli-bet/programs/ralli-bet/src/lib.rs
+++ b/programs/ralli-bet/programs/ralli-bet/src/lib.rs
@@ -100,8 +100,12 @@ pub mod ralli_bet {
         )
     }
 
-    pub fn update_line(ctx: Context<UpdateLine>, new_predicted_value: f64) -> Result<()> {
-        ctx.accounts.update_line(new_predicted_value)
+    pub fn update_line(
+        ctx: Context<UpdateLine>,
+        new_predicted_value: f64,
+        should_refund_bettors: bool
+    ) -> Result<()> {
+        ctx.accounts.update_line(new_predicted_value, should_refund_bettors)
     }
 
     // pub fn submit_bet(ctx: Context<SubmitBet>, picks: Vec<state::Pick>) -> Result<()> {


### PR DESCRIPTION
checks:-
1. only admin can update
2. line shouldnt be resolved
3. line hasnt started
4. new_predicted_value should be greater than 0.0
5. ensure new value is different from the previous predicted value